### PR TITLE
chore(docs): update preprocessing tutorial for using inst.pick() instead of pick_types()

### DIFF
--- a/tutorials/preprocessing/15_handling_bad_channels.py
+++ b/tutorials/preprocessing/15_handling_bad_channels.py
@@ -239,7 +239,7 @@ for title, data in zip(["orig.", "interp."], [eeg_data, eeg_data_interp]):
 
 # %%
 # Note that we used the ``exclude=[]`` trick in the call to
-# :meth:`~mne.io.Raw.pick_types` to make sure the bad channels were not
+# :meth:`pick()` method from the instance of `~mne.io.Raw` to make sure the bad channels were not
 # automatically dropped from the selection. Here is the corresponding example
 # with the interpolated gradiometer channel; since there are more channels
 # we'll use a more transparent gray color this time:


### PR DESCRIPTION
#### Reference issue
Closes #12158

Updated the tutorial by removing legacy method call of mne.io.Raw.pick_types() to instance.pick()


